### PR TITLE
Configure PostgreSQL and EF Core

### DIFF
--- a/PlanningPoker/PlanningPoker.API/Controllers/SampleController.cs
+++ b/PlanningPoker/PlanningPoker.API/Controllers/SampleController.cs
@@ -1,0 +1,32 @@
+using Microsoft.AspNetCore.Mvc;
+using PlanningPoker.Domain.DTOs;
+using PlanningPoker.Domain.Interfaces.Services;
+
+namespace PlanningPoker.Api.Controllers;
+
+[ApiController]
+[Route("api/[controller]")]
+public class SamplesController : ControllerBase
+{
+    private readonly ISampleService _service;
+
+    public SamplesController(ISampleService service) => _service = service;
+
+    [HttpGet]
+    public async Task<IReadOnlyList<SampleDto>> List(CancellationToken ct) =>
+        await _service.ListAsync(ct);
+
+    [HttpGet("{id:int}")]
+    public async Task<ActionResult<SampleDto>> Get(int id, CancellationToken ct)
+    {
+        var result = await _service.GetAsync(id, ct);
+        return result is null ? NotFound() : Ok(result);
+    }
+
+    [HttpPost]
+    public async Task<ActionResult<SampleDto>> Create([FromBody] CreateSampleDto dto, CancellationToken ct)
+    {
+        var created = await _service.CreateAsync(dto, ct);
+        return CreatedAtAction(nameof(Get), new { id = created.Id }, created);
+    }
+}

--- a/PlanningPoker/PlanningPoker.API/PlanningPoker.API.csproj
+++ b/PlanningPoker/PlanningPoker.API/PlanningPoker.API.csproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="10.0.6" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="10.1.7" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\PlanningPoker.BLL\PlanningPoker.BLL.csproj" />
+    <ProjectReference Include="..\PlanningPoker.Domain\PlanningPoker.Domain.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/PlanningPoker/PlanningPoker.API/PlanningPoker.API.csproj
+++ b/PlanningPoker/PlanningPoker.API/PlanningPoker.API.csproj
@@ -1,12 +1,17 @@
-<Project Sdk="Microsoft.NET.Sdk.Web">
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
+    <UserSecretsId>195dddc0-3df4-4f5b-b38e-575d8432b026</UserSecretsId>
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.6">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="10.0.6" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="10.1.7" />
   </ItemGroup>

--- a/PlanningPoker/PlanningPoker.API/PlanningPoker.API.http
+++ b/PlanningPoker/PlanningPoker.API/PlanningPoker.API.http
@@ -1,0 +1,6 @@
+@PlanningPoker.API_HostAddress = http://localhost:5249
+
+GET {{PlanningPoker.API_HostAddress}}/weatherforecast/
+Accept: application/json
+
+###

--- a/PlanningPoker/PlanningPoker.API/Program.cs
+++ b/PlanningPoker/PlanningPoker.API/Program.cs
@@ -1,0 +1,25 @@
+using PlanningPoker.BLL;
+using PlanningPoker.DAL;
+
+var builder = WebApplication.CreateBuilder(args);
+
+builder.Services.AddControllers();
+builder.Services.AddEndpointsApiExplorer();
+builder.Services.AddSwaggerGen();
+
+builder.Services.AddDalServices(builder.Configuration);
+builder.Services.AddBllServices();
+
+var app = builder.Build();
+
+if (app.Environment.IsDevelopment())
+{
+    app.UseSwagger();
+    app.UseSwaggerUI();
+}
+
+app.UseHttpsRedirection();
+app.UseAuthorization();
+app.MapControllers();
+
+app.Run();

--- a/PlanningPoker/PlanningPoker.API/Properties/launchSettings.json
+++ b/PlanningPoker/PlanningPoker.API/Properties/launchSettings.json
@@ -1,0 +1,23 @@
+﻿{
+  "$schema": "https://json.schemastore.org/launchsettings.json",
+  "profiles": {
+    "http": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "launchBrowser": false,
+      "applicationUrl": "http://localhost:5249",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    },
+    "https": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "launchBrowser": false,
+      "applicationUrl": "https://localhost:7197;http://localhost:5249",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    }
+  }
+}

--- a/PlanningPoker/PlanningPoker.API/appsettings.Development.json
+++ b/PlanningPoker/PlanningPoker.API/appsettings.Development.json
@@ -1,0 +1,8 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  }
+}

--- a/PlanningPoker/PlanningPoker.API/appsettings.Development.json
+++ b/PlanningPoker/PlanningPoker.API/appsettings.Development.json
@@ -4,5 +4,9 @@
       "Default": "Information",
       "Microsoft.AspNetCore": "Warning"
     }
+  },
+
+  "ConnectionStrings" : {
+    "Default": ""
   }
 }

--- a/PlanningPoker/PlanningPoker.API/appsettings.json
+++ b/PlanningPoker/PlanningPoker.API/appsettings.json
@@ -1,0 +1,9 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  },
+  "AllowedHosts": "*"
+}

--- a/PlanningPoker/PlanningPoker.API/appsettings.json
+++ b/PlanningPoker/PlanningPoker.API/appsettings.json
@@ -5,5 +5,9 @@
       "Microsoft.AspNetCore": "Warning"
     }
   },
-  "AllowedHosts": "*"
+  "AllowedHosts": "*",
+  
+  "ConnectionStrings" : {
+    "Default": ""
+  }
 }

--- a/PlanningPoker/PlanningPoker.BLL/PlanningPoker.BLL.csproj
+++ b/PlanningPoker/PlanningPoker.BLL/PlanningPoker.BLL.csproj
@@ -1,0 +1,14 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <ItemGroup>
+    <ProjectReference Include="..\PlanningPoker.DAL\PlanningPoker.DAL.csproj" />
+    <ProjectReference Include="..\PlanningPoker.Domain\PlanningPoker.Domain.csproj" />
+  </ItemGroup>
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+</Project>

--- a/PlanningPoker/PlanningPoker.DAL/PlanningPoker.DAL.csproj
+++ b/PlanningPoker/PlanningPoker.DAL/PlanningPoker.DAL.csproj
@@ -1,0 +1,22 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <ItemGroup>
+    <ProjectReference Include="..\PlanningPoker.Domain\PlanningPoker.Domain.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.6" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.6">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="10.0.1" />
+  </ItemGroup>
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+</Project>

--- a/PlanningPoker/PlanningPoker.Domain/PlanningPoker.Domain.csproj
+++ b/PlanningPoker/PlanningPoker.Domain/PlanningPoker.Domain.csproj
@@ -1,0 +1,9 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+</Project>

--- a/PlanningPoker/PlanningPoker.Tests/PlanningPoker.Tests.csproj
+++ b/PlanningPoker/PlanningPoker.Tests/PlanningPoker.Tests.csproj
@@ -1,0 +1,29 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" Version="6.0.4" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+    <PackageReference Include="Moq" Version="4.20.72" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.4" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\PlanningPoker.API\PlanningPoker.API.csproj" />
+    <ProjectReference Include="..\PlanningPoker.BLL\PlanningPoker.BLL.csproj" />
+    <ProjectReference Include="..\PlanningPoker.DAL\PlanningPoker.DAL.csproj" />
+    <ProjectReference Include="..\PlanningPoker.Domain\PlanningPoker.Domain.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/PlanningPoker/PlanningPoker.Tests/UnitTest1.cs
+++ b/PlanningPoker/PlanningPoker.Tests/UnitTest1.cs
@@ -1,0 +1,10 @@
+﻿namespace PlanningPoker.Tests;
+
+public class UnitTest1
+{
+    [Fact]
+    public void Test1()
+    {
+
+    }
+}

--- a/PlanningPoker/PlanningPoker.slnx
+++ b/PlanningPoker/PlanningPoker.slnx
@@ -1,0 +1,7 @@
+<Solution>
+  <Project Path="PlanningPoker.API/PlanningPoker.API.csproj" />
+  <Project Path="PlanningPoker.BLL/PlanningPoker.BLL.csproj" />
+  <Project Path="PlanningPoker.DAL/PlanningPoker.DAL.csproj" />
+  <Project Path="PlanningPoker.Domain/PlanningPoker.Domain.csproj" />
+  <Project Path="PlanningPoker.Tests/PlanningPoker.Tests.csproj" />
+</Solution>

--- a/PlanningPoker/dotnet-tools.json
+++ b/PlanningPoker/dotnet-tools.json
@@ -1,0 +1,13 @@
+{
+  "version": 1,
+  "isRoot": true,
+  "tools": {
+    "dotnet-ef": {
+      "version": "10.0.6",
+      "commands": [
+        "dotnet-ef"
+      ],
+      "rollForward": false
+    }
+  }
+}


### PR DESCRIPTION
## What changed
- configured EF Core to use connection string from configuration
- added EF Core design-time dependency required for running migrations from the API startup project

## Why
This change sets up PostgreSQL and EF Core configuration in a standard way and prepares the project for EF Core tooling and future migrations.

## How to test
1. Run `dotnet restore`
2. Ensure a valid connection string is configured locally
3. Run the API and verify it starts with database configuration applied
4. Run:
   ```bash
   dotnet ef migrations add InitialCreate --project PlanningPoker.DAL --startup-project PlanningPoker.API
