### PR TITLE
Implement transfer master

### DIFF
--- a/PlanningPoker/PlanningPoker.API/Controllers/GameParticipantController.cs
+++ b/PlanningPoker/PlanningPoker.API/Controllers/GameParticipantController.cs
@@ -3,6 +3,7 @@ using Microsoft.AspNetCore.Mvc;
 using PlanningPoker.Domain.DTOs.Game;
 using PlanningPoker.Domain.DTOs.Participant;
 using PlanningPoker.Domain.Interfaces.Services;
+using PlanningPoker.Domain.Mappers;
 
 namespace PlanningPoker.API.Controllers;
 
@@ -48,5 +49,12 @@ public class GameParticipantController(
     {
         var updatedParticipant = await participantService.UpdateDisplayNameAsync(gameId, updateDisplayNameDto.DisplayName);
         return Ok(updatedParticipant);
+    }
+
+    [HttpPatch("{gameId:guid}/participants/{participantId:guid}/transfer-master")]
+    public async Task<ActionResult> TransferMaster(Guid gameId, Guid participantId)
+    {
+        await participantService.TransferMasterAsync(gameId, participantId);
+        return NoContent();
     }
 }

--- a/PlanningPoker/PlanningPoker.BLL/Services/ParticipantService.cs
+++ b/PlanningPoker/PlanningPoker.BLL/Services/ParticipantService.cs
@@ -177,6 +177,11 @@ public class ParticipantService(
         {
             throw new ForbiddenException("delete", "participant");
         }
+
+        if (currentUserParticipant.Id == participantId)
+        {
+            throw new InvalidOperationException("You cannot delete yourself.");
+        }
         
         var participant = await participantRepository.GetActiveByIdAsync(participantId);
         if (participant is null || participant.GameId != gameId)
@@ -254,5 +259,36 @@ public class ParticipantService(
         {
             throw new ResourceAlreadyExistsException(nameof(GameParticipant), displayName); // TODO change exception
         }
+    }
+
+    public async Task TransferMasterAsync(Guid gameId, Guid participantId)
+    {
+        var currentUserId = currentUserContext.GetRequiredUserId();
+        await GetGameOrThrowAsync(gameId);
+
+        var currentUserParticipant = await participantRepository.GetByUserIdAndGameIdAsync(currentUserId, gameId);
+        if (currentUserParticipant is null || currentUserParticipant.Role != ParticipantRole.Master)
+        {
+            throw new ForbiddenException("transfer master to", "participant");
+        }
+        
+        var participant = await participantRepository.GetActiveByIdAsync(participantId);
+        if (participant is null || participant.GameId != gameId)
+        {
+            throw new NotFoundException(nameof(GameParticipant), participantId);
+        }
+
+        if (currentUserParticipant.Id == participantId)
+        {
+            throw new InvalidOperationException("You cannot transfer master role to yourself.");
+        }
+        
+        currentUserParticipant.Role = ParticipantRole.Player;
+        participantRepository.Update(currentUserParticipant);
+        
+        participant.Role = ParticipantRole.Master;
+        participantRepository.Update(participant);
+        
+        await participantRepository.SaveChangesAsync();
     }
 }

--- a/PlanningPoker/PlanningPoker.BLL/Services/ParticipantService.cs
+++ b/PlanningPoker/PlanningPoker.BLL/Services/ParticipantService.cs
@@ -228,6 +228,54 @@ public class ParticipantService(
         await participantRepository.SaveChangesAsync();
         return ParticipantMapper.ToGameParticipantDto(currentUserParticipant);
     }
+    
+      /// <summary>
+    /// Передає роль Master іншому активному учаснику в межах конкретної гри.
+    /// Операцію може виконати лише поточний Master цієї гри.
+    /// Після успішної передачі поточний Master отримує роль Player, а вибраний учасник стає новим Master.
+    /// </summary>
+    /// <param name="gameId">Ідентифікатор гри.</param>
+    /// <param name="participantId">Ідентифікатор учасника, якому потрібно передати роль Master.</param>
+    /// <returns>Асинхронна операція без повернення значення.</returns>
+    /// <exception cref="NotFoundException">
+    /// Виникає, якщо гру або вказаного учасника не знайдено.
+    /// </exception>
+    /// <exception cref="ForbiddenException">
+    /// Виникає, якщо поточний користувач не є Master цієї гри.
+    /// </exception>
+    /// <exception cref="InvalidOperationException">
+    /// Виникає, якщо користувач намагається передати роль Master самому собі.
+    /// </exception>
+    public async Task TransferMasterAsync(Guid gameId, Guid participantId)
+    {
+        var currentUserId = currentUserContext.GetRequiredUserId();
+        await GetGameOrThrowAsync(gameId);
+
+        var currentUserParticipant = await participantRepository.GetByUserIdAndGameIdAsync(currentUserId, gameId);
+        if (currentUserParticipant is null || currentUserParticipant.Role != ParticipantRole.Master)
+        {
+            throw new ForbiddenException("transfer master to", "participant");
+        }
+        
+        var participant = await participantRepository.GetActiveByIdAsync(participantId);
+        if (participant is null || participant.GameId != gameId)
+        {
+            throw new NotFoundException(nameof(GameParticipant), participantId);
+        }
+
+        if (currentUserParticipant.Id == participantId)
+        {
+            throw new InvalidOperationException("You cannot transfer master role to yourself.");
+        }
+        
+        currentUserParticipant.Role = ParticipantRole.Player;
+        participantRepository.Update(currentUserParticipant);
+        
+        participant.Role = ParticipantRole.Master;
+        participantRepository.Update(participant);
+        
+        await participantRepository.SaveChangesAsync();
+    }
 
     /// <summary>
     /// Повертає гру за ідентифікатором або викидає виняток, якщо гру не знайдено.
@@ -259,36 +307,5 @@ public class ParticipantService(
         {
             throw new ResourceAlreadyExistsException(nameof(GameParticipant), displayName); // TODO change exception
         }
-    }
-
-    public async Task TransferMasterAsync(Guid gameId, Guid participantId)
-    {
-        var currentUserId = currentUserContext.GetRequiredUserId();
-        await GetGameOrThrowAsync(gameId);
-
-        var currentUserParticipant = await participantRepository.GetByUserIdAndGameIdAsync(currentUserId, gameId);
-        if (currentUserParticipant is null || currentUserParticipant.Role != ParticipantRole.Master)
-        {
-            throw new ForbiddenException("transfer master to", "participant");
-        }
-        
-        var participant = await participantRepository.GetActiveByIdAsync(participantId);
-        if (participant is null || participant.GameId != gameId)
-        {
-            throw new NotFoundException(nameof(GameParticipant), participantId);
-        }
-
-        if (currentUserParticipant.Id == participantId)
-        {
-            throw new InvalidOperationException("You cannot transfer master role to yourself.");
-        }
-        
-        currentUserParticipant.Role = ParticipantRole.Player;
-        participantRepository.Update(currentUserParticipant);
-        
-        participant.Role = ParticipantRole.Master;
-        participantRepository.Update(participant);
-        
-        await participantRepository.SaveChangesAsync();
     }
 }

--- a/PlanningPoker/PlanningPoker.DAL/Repositories/GameRepository.cs
+++ b/PlanningPoker/PlanningPoker.DAL/Repositories/GameRepository.cs
@@ -29,6 +29,7 @@ internal class GameRepository(AppDbContext context) : BaseRepository<Game>(conte
     {
         return await _dbSet
             .Include(g => g.Participants.Where(participant => participant.RemovedAt == null))
+            .Include(g => g.Issues.Where(issue => !issue.IsRemoved))
             .FirstOrDefaultAsync(g => g.Id == id);
     }
 
@@ -36,6 +37,7 @@ internal class GameRepository(AppDbContext context) : BaseRepository<Game>(conte
     {
         return await _dbSet
             .Include(g => g.Participants.Where(participant => participant.RemovedAt == null))
+            .Include(g => g.Issues.Where(issue => !issue.IsRemoved))
             .FirstOrDefaultAsync(g => g.InviteCode == inviteCode && !g.IsDeleted);
     }
 }

--- a/PlanningPoker/PlanningPoker.Domain/DTOs/Game/GameDto.cs
+++ b/PlanningPoker/PlanningPoker.Domain/DTOs/Game/GameDto.cs
@@ -1,3 +1,4 @@
+using PlanningPoker.BLL.DTOs.Issue;
 using PlanningPoker.Domain.Models;
 
 namespace PlanningPoker.Domain.DTOs.Game;
@@ -14,5 +15,6 @@ public class GameDto
     public bool IsActive { get; set; }
     public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
     public Guid? CreatedBy { get; set; }
-    public ICollection<GameParticipantDto> Participants { get; set; } = [];
+    public ICollection<GameParticipantDto>? Participants { get; set; }
+    public ICollection<IssueDto>? Issues { get; set; }
 }

--- a/PlanningPoker/PlanningPoker.Domain/Interfaces/Services/IParticipantService.cs
+++ b/PlanningPoker/PlanningPoker.Domain/Interfaces/Services/IParticipantService.cs
@@ -10,4 +10,5 @@ public interface IParticipantService
     public Task LeaveGameAsync(Guid gameId);
     public Task DeleteGameParticipantAsync(Guid gameId, Guid participantId);
     public Task<GameParticipantDto> UpdateDisplayNameAsync(Guid gameId, string? displayName);
+    public Task TransferMasterAsync(Guid gameId, Guid participantId);
 }

--- a/PlanningPoker/PlanningPoker.Domain/Mappers/GameMapper.cs
+++ b/PlanningPoker/PlanningPoker.Domain/Mappers/GameMapper.cs
@@ -42,9 +42,13 @@ public static class GameMapper
             IsActive = game.IsActive,
             CreatedAt =  game.CreatedAt,
             CreatedBy = game.CreatedBy,
-            Participants = game.Participants
+            Participants = (game.Participants ?? [])
                 .Where(participant => participant.RemovedAt == null)
                 .Select(ParticipantMapper.ToGameParticipantDto)
+                .ToList(),
+            Issues = (game.Issues ?? [])
+                .Where(issue => !issue.IsRemoved)
+                .Select(IssueMapper.ToDto)
                 .ToList()
         };
 }

--- a/PlanningPoker/PlanningPoker.Domain/Models/Game.cs
+++ b/PlanningPoker/PlanningPoker.Domain/Models/Game.cs
@@ -15,7 +15,7 @@ public class Game
     public Guid CreatedBy { get; set; }
     public User CreatedByUser { get; set; } = null!;
     public ICollection<GameParticipant> Participants { get; set; } = new List<GameParticipant>();
-    public ICollection<Issue> Issues { get; set; } = null!;
+    public ICollection<Issue> Issues { get; set; } = new List<Issue>();
     public ICollection<Vote> Votes { get; set; } = new List<Vote>();
 }
 

--- a/PlanningPoker/PlanningPoker.Tests/Controllers/GameParticipantControllerTests.cs
+++ b/PlanningPoker/PlanningPoker.Tests/Controllers/GameParticipantControllerTests.cs
@@ -122,6 +122,34 @@ public class GameParticipantControllerTests
         _participantService.Verify(service => service.DeleteGameParticipantAsync(gameId, participantId), Times.Once);
     }
 
+    [Fact]
+    public async Task TransferMaster_WhenServiceSucceeds_ReturnsNoContent()
+    {
+        var gameId = Guid.NewGuid();
+        var participantId = Guid.NewGuid();
+
+        var result = await _controller.TransferMaster(gameId, participantId);
+
+        Assert.IsType<NoContentResult>(result);
+        _participantService.Verify(service => service.TransferMasterAsync(gameId, participantId), Times.Once);
+    }
+
+    [Fact]
+    public async Task TransferMaster_WhenUserDoesNotHaveRights_ThrowsException()
+    {
+        var gameId = Guid.NewGuid();
+        var participantId = Guid.NewGuid();
+
+        _participantService
+            .Setup(service => service.TransferMasterAsync(gameId, participantId))
+            .ThrowsAsync(new ForbiddenException("transfer master to", "participant"));
+
+        var act = async () => await _controller.TransferMaster(gameId, participantId);
+
+        await Assert.ThrowsAsync<ForbiddenException>(act);
+        _participantService.Verify(service => service.TransferMasterAsync(gameId, participantId), Times.Once);
+    }
+
     private static GameParticipantDto CreateParticipantDto(string displayName, ParticipantRole role)
     {
         return new GameParticipantDto

--- a/PlanningPoker/PlanningPoker.Tests/Services/GameServiceTests.cs
+++ b/PlanningPoker/PlanningPoker.Tests/Services/GameServiceTests.cs
@@ -127,6 +127,23 @@ public class GameServiceTests
     }
 
     [Fact]
+    public async Task GetGameByIdAsync_WhenGameCollectionsAreNull_ReturnsEmptyCollections()
+    {
+        var game = CreateGame("newGame", VotingSystem.Custom, true);
+        game.Participants = null!;
+        game.Issues = null!;
+
+        _gameRepository.Setup(repository => repository.GetByIdAsync(game.Id)).ReturnsAsync(game);
+
+        var result = await _gameService.GetGameByIdAsync(game.Id);
+
+        Assert.NotNull(result.Participants);
+        Assert.NotNull(result.Issues);
+        Assert.Empty(result.Participants);
+        Assert.Empty(result.Issues);
+    }
+
+    [Fact]
     public async Task GetGameByIdAsync_WhenGameDoesNotExist_ThrowsNotFoundException()
     {
         var gameId = Guid.NewGuid();

--- a/PlanningPoker/PlanningPoker.Tests/Services/ParticipantServiceTests.cs
+++ b/PlanningPoker/PlanningPoker.Tests/Services/ParticipantServiceTests.cs
@@ -357,6 +357,105 @@ public class ParticipantServiceTests
         _participantRepository.Verify(repository => repository.SaveChangesAsync(), Times.Never);
     }
 
+    [Fact]
+    public async Task TransferMasterAsync_WhenGameDoesNotExist_ThrowsNotFoundException()
+    {
+        var participantId = Guid.NewGuid();
+
+        SetupCurrentUserId(_masterId);
+        _gameRepository.Setup(repository => repository.GetByIdAsync(_gameId)).ReturnsAsync((Game?)null);
+
+        var act = async () => await _participantService.TransferMasterAsync(_gameId, participantId);
+
+        await Assert.ThrowsAsync<NotFoundException>(act);
+        _participantRepository.Verify(repository => repository.Update(It.IsAny<GameParticipant>()), Times.Never);
+        _participantRepository.Verify(repository => repository.SaveChangesAsync(), Times.Never);
+    }
+
+    [Fact]
+    public async Task TransferMasterAsync_WhenCurrentUserIsNotMaster_ThrowsForbiddenException()
+    {
+        var participantId = Guid.NewGuid();
+
+        SetupCurrentUserId(_playerId);
+        _gameRepository.Setup(repository => repository.GetByIdAsync(_gameId)).ReturnsAsync(CreateGame("invite-code", isActive: true, _gameId));
+        _participantRepository
+            .Setup(repository => repository.GetByUserIdAndGameIdAsync(_playerId, _gameId))
+            .ReturnsAsync(CreateParticipant(_playerId, _gameId, ParticipantRole.Player, "Player"));
+
+        var act = async () => await _participantService.TransferMasterAsync(_gameId, participantId);
+
+        await Assert.ThrowsAsync<ForbiddenException>(act);
+        _participantRepository.Verify(repository => repository.Update(It.IsAny<GameParticipant>()), Times.Never);
+        _participantRepository.Verify(repository => repository.SaveChangesAsync(), Times.Never);
+    }
+
+    [Fact]
+    public async Task TransferMasterAsync_WhenParticipantDoesNotExist_ThrowsNotFoundException()
+    {
+        var participantId = Guid.NewGuid();
+
+        SetupCurrentUserId(_masterId);
+        _gameRepository.Setup(repository => repository.GetByIdAsync(_gameId)).ReturnsAsync(CreateGame("invite-code", isActive: true, _gameId));
+        _participantRepository
+            .Setup(repository => repository.GetByUserIdAndGameIdAsync(_masterId, _gameId))
+            .ReturnsAsync(CreateParticipant(_masterId, _gameId, ParticipantRole.Master, "Master"));
+        _participantRepository
+            .Setup(repository => repository.GetActiveByIdAsync(participantId))
+            .ReturnsAsync((GameParticipant?)null);
+
+        var act = async () => await _participantService.TransferMasterAsync(_gameId, participantId);
+
+        await Assert.ThrowsAsync<NotFoundException>(act);
+        _participantRepository.Verify(repository => repository.Update(It.IsAny<GameParticipant>()), Times.Never);
+        _participantRepository.Verify(repository => repository.SaveChangesAsync(), Times.Never);
+    }
+
+    [Fact]
+    public async Task TransferMasterAsync_WhenTargetIsCurrentUser_ThrowsInvalidOperationException()
+    {
+        var masterParticipant = CreateParticipant(_masterId, _gameId, ParticipantRole.Master, "Master");
+
+        SetupCurrentUserId(_masterId);
+        _gameRepository.Setup(repository => repository.GetByIdAsync(_gameId)).ReturnsAsync(CreateGame("invite-code", isActive: true, _gameId));
+        _participantRepository
+            .Setup(repository => repository.GetByUserIdAndGameIdAsync(_masterId, _gameId))
+            .ReturnsAsync(masterParticipant);
+        _participantRepository
+            .Setup(repository => repository.GetActiveByIdAsync(masterParticipant.Id))
+            .ReturnsAsync(masterParticipant);
+
+        var act = async () => await _participantService.TransferMasterAsync(_gameId, masterParticipant.Id);
+
+        await Assert.ThrowsAsync<InvalidOperationException>(act);
+        _participantRepository.Verify(repository => repository.Update(It.IsAny<GameParticipant>()), Times.Never);
+        _participantRepository.Verify(repository => repository.SaveChangesAsync(), Times.Never);
+    }
+
+    [Fact]
+    public async Task TransferMasterAsync_WhenCurrentUserIsMaster_TransfersRightsAndSavesChanges()
+    {
+        var masterParticipant = CreateParticipant(_masterId, _gameId, ParticipantRole.Master, "Master");
+        var playerParticipant = CreateParticipant(_playerId, _gameId, ParticipantRole.Player, "Player");
+
+        SetupCurrentUserId(_masterId);
+        _gameRepository.Setup(repository => repository.GetByIdAsync(_gameId)).ReturnsAsync(CreateGame("invite-code", isActive: true, _gameId));
+        _participantRepository
+            .Setup(repository => repository.GetByUserIdAndGameIdAsync(_masterId, _gameId))
+            .ReturnsAsync(masterParticipant);
+        _participantRepository
+            .Setup(repository => repository.GetActiveByIdAsync(playerParticipant.Id))
+            .ReturnsAsync(playerParticipant);
+
+        await _participantService.TransferMasterAsync(_gameId, playerParticipant.Id);
+
+        Assert.Equal(ParticipantRole.Player, masterParticipant.Role);
+        Assert.Equal(ParticipantRole.Master, playerParticipant.Role);
+        _participantRepository.Verify(repository => repository.Update(masterParticipant), Times.Once);
+        _participantRepository.Verify(repository => repository.Update(playerParticipant), Times.Once);
+        _participantRepository.Verify(repository => repository.SaveChangesAsync(), Times.Once);
+    }
+
     private void SetupCurrentUser(User user)
     {
         _currentUserContext.Setup(context => context.GetRequiredUserAsync()).ReturnsAsync(user);


### PR DESCRIPTION
## What changed

- implemented master role transfer for game participants  
- added endpoint to transfer master rights to another participant within the same game  
- added unit tests for controller and service scenarios around master transfer  

## Why

This change adds flow for reassigning game ownership during an active session and makes the permission and error handling around master transfer consistent with the rest of the participant logic.

## How to test

`dotnet test`

### Manual check:

1. create a game as Master  
2. add another participant to the game  
3. call the transfer master endpoint for that participant  
4. verify the current Master becomes `Player` and the selected participant becomes `Master`  
5. try to transfer rights to yourself and verify the request fails  
6. try to transfer rights as a non-master and verify access is denied  
7. try to transfer rights to a participant from another game or a non-existing participant and verify the request fails  
8. try to transfer rights for a non-existing game and verify `404 Not Found` is returned  
